### PR TITLE
Strawman to error out if the kb-sdk tests fail

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -58,5 +58,4 @@ jobs:
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       run: |
-        sh $GITHUB_WORKSPACE/kb_sdk_actions/bin/kb-sdk test
-        bash <(curl -s https://codecov.io/bash)
+        sh $GITHUB_WORKSPACE/kb_sdk_actions/bin/kb-sdk test && bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
The template currently masks the fact that kb-sdk tests can fail, because the "Run tests" action only cares about the exit code for the codecov script.